### PR TITLE
A small bug fix: Convert coordinates into float in _lookUp function

### DIFF
--- a/geocoder.js
+++ b/geocoder.js
@@ -681,6 +681,10 @@ var geocoder = {
     }
     var functions = [];
     points.forEach(function(point, i) {
+      point = {
+		latitude: parseFloat(point.latitude),
+		longitude: parseFloat(point.longitude)
+	  };
       functions[i] = function(innerCallback) {
         var result = that._kdTree.nearest(point, maxResults);
         result.reverse();

--- a/geocoder.js
+++ b/geocoder.js
@@ -682,9 +682,9 @@ var geocoder = {
     var functions = [];
     points.forEach(function(point, i) {
       point = {
-		latitude: parseFloat(point.latitude),
-		longitude: parseFloat(point.longitude)
-	  };
+        latitude: parseFloat(point.latitude),
+        longitude: parseFloat(point.longitude)
+      };
       functions[i] = function(innerCallback) {
         var result = that._kdTree.nearest(point, maxResults);
         result.reverse();


### PR DESCRIPTION
Hi,

I guess there is a bug in the application while working in web-service mode

If you make a http://localhost:3000/geocode?latitude=55.749087&longitude=37.620116 request (which is the POI coordinates within Moscow) the nearest city returns as follows:

```
{
    "geoNameId": "745407",
    "name": "İğdir",
    "asciiName": "Igdir",
    "alternateNames": "Igdir,İğdir",
    "latitude": "40.26633",
    "longitude": "35.62645",
 
 ...
 
}

```
Looks like kdTree.nearest() cannot work with strings because once you convert the coordinates into float, geocoder starts sending the right data:

```
{
    geoNameId: '524901',
      name: 'Moscow',
      asciiName: 'Moscow',
      alternateNames: 'Gorad Maskva,MOW,Maeskuy,Maskav,Maskava ...',
      latitude: '55.75222',
      longitude: '37.61556',
   
   ...
   
}
```

Regards, Vlad.