### PR TITLE
Add Dockerfile for use with project.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:10.12.0-alpine
+
+WORKDIR /app
+
+ADD package.json package-lock.json /app/
+RUN npm install
+ADD app.js geocoder.js /app/
+
+RUN apk add --no-cache curl && \
+    mkdir -p \
+        /app/geonames_dump/admin1_codes \
+        /app/geonames_dump/admin2_codes \
+        /app/geonames_dump/all_countries \
+        /app/geonames_dump/alternate_names \
+        /app/geonames_dump/cities && \
+    cd /app/geonames_dump && \
+    curl -L -o admin1_codes/admin1CodesASCII.txt http://download.geonames.org/export/dump/admin1CodesASCII.txt && \
+    curl -L -o admin2_codes/admin2Codes.txt http://download.geonames.org/export/dump/admin2Codes.txt && \
+    curl -L -o all_countries/allCountries.zip http://download.geonames.org/export/dump/allCountries.zip && \
+    curl -L -o alternate_names/alternateNames.zip http://download.geonames.org/export/dump/alternateNames.zip && \
+    curl -L -o cities/cities1000.zip http://download.geonames.org/export/dump/cities1000.zip && \
+    cd all_countries && unzip allCountries.zip && rm allCountries.zip && cd .. && \
+    cd cities && unzip cities1000.zip && rm cities1000.zip && cd .. && \
+    cd alternate_names && unzip alternateNames.zip && rm alternateNames.zip
+
+ENTRYPOINT ["npm"]
+CMD ["start"]
+

--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ You can use the built-in Web service by running `node app.js` as follows.
 $ curl "http://localhost:3000/geocode?latitude=48.466667&longitude=9.133333&latitude=42.083333&longitude=3.1&maxResults=2"
 ```
 
+# Dockerfile
+
+For usage with [Docker](https://www.docker.com/), a Dockerfile is available in this project. It caches all the required files from GeoNames.
+
+To use it:
+
+```bash
+$ docker build -t local-reverse-geocoder .
+$ docker run -it -e PORT=3000 --rm local-reverse-geocoder
+```
+
 # Result Format
 
 An output array that maps each point in the input array (or input object converted to a single-element array) to the `maxResults` closest addresses.


### PR DESCRIPTION
In some cases, it's convenient (and desirable) to download the GeoNames database ahead of time to speed up initialization. In our case, where most of our services run on Kubernetes as `Deployments`, we prefer to have the GeoNames database baked into a Docker image.

It also works in the case where we want to scale up the deployment.

This PR adds a Dockerfile for such a use case and accompanying usage instructions.