### PR TITLE
Add citiesFileOverride and citites to the InitOptions interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ export interface InitOptions {
   dumpDirectory?: string;
   load?: InitLoadOptions;
   citiesFileOverride?: string;
-  countries: string[];
+  countries?: string[];
 }
 
 declare const _default: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,7 @@ export interface InitLoadOptions {
 export interface InitOptions {
   dumpDirectory?: string;
   load?: InitLoadOptions;
+  citiesFileOverride?: string;
 }
 
 declare const _default: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,7 @@ export interface InitOptions {
   dumpDirectory?: string;
   load?: InitLoadOptions;
   citiesFileOverride?: string;
+  countries: string[];
 }
 
 declare const _default: {


### PR DESCRIPTION
The InitOptions interface was missing the citiesFileOverride and countries options which causes issues in typescript solutions.

PS: Thanks for the awesome library!