### PR TITLE
Allow to download the GeoNames data at post-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,12 +319,16 @@ like Google's
 
 The initial lookup takes quite a while, as the geocoder has to download roughly
 2GB(!) of data that it then caches locally (unzipped, this occupies about 1.3GB
-of disk space). All follow-up requests are lightning fast. To reduce the time
-taken to initialize the data, you can manually configure it to only download a
-specific set of countries from Geonames. Do note that when you add a country
-code into the array, it will disable geocoder from downloading all ~2GB(!) worth
-of data and only load the specified countries' data. If you want to re-enable
-geocoder to download all data, the countries array needs to be empty.
+of disk space). All follow-up requests are lightning fast.
+
+### Downloading specific sets of countries
+
+To reduce the time taken to initialize the data, you can manually configure it
+to only download a specific set of countries from Geonames. Do note that when
+you add a country code into the array, it will disable geocoder from downloading
+all ~2GB(!) worth of data and only load the specified countries' data. If you
+want to re-enable geocoder to download all data, the countries array needs to be
+empty.
 
 #### Example of getting data for individual country
 
@@ -345,6 +349,26 @@ geocoder.init(
     // Ready to call lookUp
   }
 );
+```
+
+### Post-install script
+
+There's also the option of downloading the Geonames files via a post-install
+script.  
+The script is invoked automatically after installation but won't download any
+files without getting at least one of the init options in an env variable.  
+The options should be specific with a `GEOCODER_POSTINSTALL_` prefix.
+
+#### Example of downloading the files via the post-install script
+
+```javascript
+export GEOCODER_POSTINSTALL_ADMIN1=true
+export GEOCODER_POSTINSTALL_ADMIN2=true
+export GEOCODER_POSTINSTALL_COUNTRIES=SG,AU
+npm install local-reverse-geocoder
+
+// As long as the app is started within the same day
+// and uses the same options, the init call won't download any files.
 ```
 
 ## A Word on Data Freshness

--- a/README.md
+++ b/README.md
@@ -325,9 +325,9 @@ of disk space). All follow-up requests are lightning fast.
 
 To reduce the time taken to initialize the data, you can manually configure it
 to only download a specific set of countries from Geonames. Do note that when
-you add a country code into the array, it will disable geocoder from downloading
+you add a country code into the array, it will disable the geocoder from downloading
 all ~2GB(!) worth of data and only load the specified countries' data. If you
-want to re-enable geocoder to download all data, the countries array needs to be
+want to re-enable the geocoder to download all data, the countries array needs to be
 empty.
 
 #### Example of getting data for individual country
@@ -355,13 +355,13 @@ geocoder.init(
 
 There's also the option of downloading the Geonames files via a post-install
 script.  
-The script is invoked automatically after installation but won't download any
+The script is invoked automatically after installation, but won't download any
 files without getting at least one of the init options in an env variable.  
-The options should be specific with a `GEOCODER_POSTINSTALL_` prefix.
+The options should be specified with a `GEOCODER_POSTINSTALL_` prefix.
 
 #### Example of downloading the files via the post-install script
 
-```javascript
+```js
 export GEOCODER_POSTINSTALL_ADMIN1=true
 export GEOCODER_POSTINSTALL_ADMIN2=true
 export GEOCODER_POSTINSTALL_COUNTRIES=SG,AU

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-reverse-geocoder",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Implements a local reverse geocoder based on GeoNames.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "jshint --exclude ./node_modules,./docs/scripts .",
     "start": "node --max-old-space-size=4096 app.js",
     "build": "jsdoc -d docs index.js",
-    "prettier": "prettier --write *.{js,md,json}"
+    "prettier": "prettier --write *.{js,md,json}",
+    "postinstall": "node --max-old-space-size=4096 postinstall.js"
   },
   "keywords": [
     "geocoding",

--- a/postinstall.js
+++ b/postinstall.js
@@ -20,14 +20,14 @@ const values = [
 ];
 if (values.every((val) => typeof val === 'undefined')) {
   console.info(
-    '[local-reverse-geocoder] post-install: No env variables detected. Doing nothing'
+    '[local-reverse-geocoder] post-install: No env variables detected. Doing nothing.'
   );
   process.exit(0);
 }
 
 const geocoder = require('./index');
 try {
-  console.info('[local-reverse-geocoder] post-install: Starting');
+  console.info('[local-reverse-geocoder] post-install: Starting.');
   geocoder.init(
     {
       citiesFileOverride: GEOCODER_POSTINSTALL_CITIES_FILE_OVERRIDE,
@@ -41,20 +41,20 @@ try {
       countries: GEOCODER_POSTINSTALL_COUNTRIES?.split(',') || [],
     },
     function () {
-      console.info('[local-reverse-geocoder] post-install: Finished');
+      console.info('[local-reverse-geocoder] post-install: Finished.');
       process.exit(0);
     }
   );
 } catch (error) {
   if (GEOCODER_POSTINSTALL_FAIL_SILENTLY?.toLowerCase() === 'true') {
     console.warn(
-      '[local-reverse-geocoder] post-install: An error occurred. Detected fail-silently flag',
+      '[local-reverse-geocoder] post-install: An error occurred. Detected fail-silently flag.',
       error
     );
     process.exit(0);
   } else {
     console.error(
-      '[local-reverse-geocoder] post-install: An error occurred',
+      '[local-reverse-geocoder] post-install: An error occurred.',
       error
     );
     process.exit(1);

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,62 @@
+const {
+  GEOCODER_POSTINSTALL_DUMP_DIRECTORY,
+  GEOCODER_POSTINSTALL_CITIES_FILE_OVERRIDE,
+  GEOCODER_POSTINSTALL_ADMIN1,
+  GEOCODER_POSTINSTALL_ADMIN2,
+  GEOCODER_POSTINSTALL_ADMIN3_AND_4,
+  GEOCODER_POSTINSTALL_ALTERNATE_NAMES,
+  GEOCODER_POSTINSTALL_COUNTRIES,
+  GEOCODER_POSTINSTALL_FAIL_SILENTLY,
+} = process.env;
+
+const values = [
+  GEOCODER_POSTINSTALL_DUMP_DIRECTORY,
+  GEOCODER_POSTINSTALL_CITIES_FILE_OVERRIDE,
+  GEOCODER_POSTINSTALL_ADMIN1,
+  GEOCODER_POSTINSTALL_ADMIN2,
+  GEOCODER_POSTINSTALL_ADMIN3_AND_4,
+  GEOCODER_POSTINSTALL_ALTERNATE_NAMES,
+  GEOCODER_POSTINSTALL_COUNTRIES,
+];
+if (values.every((val) => typeof val === 'undefined')) {
+  console.info(
+    '[local-reverse-geocoder] post-install: No env variables detected. Doing nothing'
+  );
+  process.exit(0);
+}
+
+const geocoder = require('./index');
+try {
+  console.info('[local-reverse-geocoder] post-install: Starting');
+  geocoder.init(
+    {
+      citiesFileOverride: GEOCODER_POSTINSTALL_CITIES_FILE_OVERRIDE,
+      load: {
+        admin1: GEOCODER_POSTINSTALL_ADMIN1?.toLowerCase() === 'true',
+        admin2: GEOCODER_POSTINSTALL_ADMIN2?.toLowerCase() === 'true',
+        admin3And4: GEOCODER_POSTINSTALL_ADMIN3_AND_4?.toLowerCase() === 'true',
+        alternateNames:
+          GEOCODER_POSTINSTALL_ALTERNATE_NAMES?.toLowerCase() === 'true',
+      },
+      countries: GEOCODER_POSTINSTALL_COUNTRIES?.split(',') || [],
+    },
+    function () {
+      console.info('[local-reverse-geocoder] post-install: Finished');
+      process.exit(0);
+    }
+  );
+} catch (error) {
+  if (GEOCODER_POSTINSTALL_FAIL_SILENTLY?.toLowerCase() === 'true') {
+    console.warn(
+      '[local-reverse-geocoder] post-install: An error occurred. Detected fail-silently flag',
+      error
+    );
+    process.exit(0);
+  } else {
+    console.error(
+      '[local-reverse-geocoder] post-install: An error occurred',
+      error
+    );
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
My second PR for this project :)

Addressing the suggestion at #53, this PR includes the following:
* A post-install script which runs the initialization function.
The parameters are passed via env-variables.
* A short description & example in the documentation
* All of the methods used here are supported from Node v6+, no breaking changes

Please let me know what you think:
* The files are tagged with the current date so initializing at a different date will not gain anything from this effort
Should there be an initialization option to save the files without a date tag?
* Should the `Dockerfile` be modified to use this post-install script instead of `curl`?
It will thereby get more usage and better feedback