### PR TITLE
Fix post-install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ The options should be specified with a `GEOCODER_POSTINSTALL_` prefix.
 #### Example of downloading the files via the post-install script
 
 ```js
+export GEOCODER_POSTINSTALL_DUMP_DIRECTORY=/usr/src/app
 export GEOCODER_POSTINSTALL_ADMIN1=true
 export GEOCODER_POSTINSTALL_ADMIN2=true
 export GEOCODER_POSTINSTALL_COUNTRIES=SG,AU

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "files": [
     "app.js",
+    "postinstall.js",
     "index.js",
     "index.d.ts"
   ],

--- a/postinstall.js
+++ b/postinstall.js
@@ -30,6 +30,7 @@ try {
   console.info('[local-reverse-geocoder] post-install: Starting.');
   geocoder.init(
     {
+      dumpDirectory: GEOCODER_POSTINSTALL_DUMP_DIRECTORY,
       citiesFileOverride: GEOCODER_POSTINSTALL_CITIES_FILE_OVERRIDE,
       load: {
         admin1: GEOCODER_POSTINSTALL_ADMIN1?.toLowerCase() === 'true',


### PR DESCRIPTION
1. Expose the script in the files-list @ `package.json`: caused some installs to fail
2. Add the ability to configure the dump-directory (default would be in the package's folder).
The env-variable was read and validated but not passed to the init function.

I suggest to also remove the previous release from npm as a precaution.