### PR TITLE
Fix tree building when using specific countries

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   },
   "homepage": "https://github.com/tomayac/local-reverse-geocoder",
   "engines": {
-    "node": ">=10.15.0",
-    "npm": ">=6.0.0"
+    "node": ">=11.0.0",
+    "npm": ">=6.4.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",


### PR DESCRIPTION
A fix for the problem specified in #46.

The tree was being rebuilt for every country so it only had the data of the last country in the list.
This change will aggregate the data from all of the countries using `async.parallel`
and build the tree once after the files finished downloading and parsing.

I increased the minimum Node.js version (and appropriate NPM version) because of the use of `.flat()`