### PR TITLE
Changed max-old-space-size to just below 4GB - Bring back 32bit arch support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "lint": "jshint --exclude ./node_modules,./docs/scripts .",
-    "start": "node --max-old-space-size=4096 app.js",
+    "start": "node --max-old-space-size=4095 app.js",
     "build": "jsdoc -d docs index.js",
     "prettier": "prettier --write *.{js,md,json}",
     "postinstall": "node --max-old-space-size=4096 postinstall.js"


### PR DESCRIPTION
Dirty fix for https://github.com/tomayac/local-reverse-geocoder/issues/67

Disclaimer: I'm not a Node.js developer. I'm just facing the problem of https://github.com/tomayac/local-reverse-geocoder/issues/67 and deduced that this would be a fast solution for the problem.