### PR TITLE
change temp file path to be in existing directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,6 @@ var request = require('request');
 var unzip = require('unzip-stream');
 var async = require('async');
 var readline = require('readline');
-var os = require("os");
-const tempDir = os.tmpdir();
 const { basename } = require('path');
 
 // All data from http://download.geonames.org/export/dump/
@@ -186,7 +184,7 @@ var geocoder = {
   ) {
     const geonamesUrl = `${GEONAMES_URL}${geonamesZipFilename}`;
     const outputFilePath = `${outputFileFolderWithoutSlash}/${outputFileName}`;
-    const tempFilePath = `${tempDir}/${outputFileName}`;
+    const tempFilePath = `${outputFileFolderWithoutSlash}/temp-${outputFileName}`;
     debug(
       `Getting GeoNames ${dataName} data from ${geonamesUrl} (this may take a while)`
     );
@@ -226,7 +224,7 @@ var geocoder = {
   ) {
     const geonamesUrl = `${GEONAMES_URL}${geonamesZipFilename}`;
     const outputFilePath = `${outputFileFolderWithoutSlash}/${outputFileName}`;
-    const tempFilePath = `${tempDir}/${outputFileName}`;
+    const tempFilePath = `${outputFileFolderWithoutSlash}/temp-${outputFileName}`;
 
     debug(
       `Getting GeoNames ${dataName} data from ${geonamesUrl} (this may take a while)`
@@ -294,7 +292,7 @@ var geocoder = {
   },
 
   _housekeepingSync: function (outputFileFolderWithoutSlash, outputFileName) {
-    const tempFilePath = `${tempDir}/${outputFileName}`;
+    const tempFilePath = `${outputFileFolderWithoutSlash}/temp-${outputFileName}`;
     if (fs.existsSync(tempFilePath)) {
       fs.renameSync(tempFilePath, `${outputFileFolderWithoutSlash}/${outputFileName}`);
       fs.readdirSync(outputFileFolderWithoutSlash).forEach((foundFile) => {


### PR DESCRIPTION
https://github.com/tomayac/local-reverse-geocoder/pull/64 caused the below error in a downstream system:

```
Error: EXDEV: cross-device link not permitted, rename '/tmp/admin1CodesASCII_2023-05-09.txt' -> '/geodata-cache/admin1_codes/admin1CodesASCII_2023-05-09.txt'                                                                                                
    at Object.renameSync (node:fs:993:3)                                                                                                                                                                                                                     
    at Object._housekeepingSync (/usr/src/app/node_modules/local-reverse-geocoder/index.js:299:10)                                                                                                                                                           
    at WriteStream.<anonymous> (/usr/src/app/node_modules/local-reverse-geocoder/index.js:214:14)                                                                                                                                                            
    at WriteStream.emit (node:events:527:28)                                                                                                                                                                                                                 
    at finish (node:internal/streams/writable:754:10)                                                                                                                                                                                                        
    at finishMaybe (node:internal/streams/writable:739:9)                                                                                                                                                                                                    
    at afterWrite (node:internal/streams/writable:504:3)                                                                                                                                                                                                     
    at onwrite (node:internal/streams/writable:477:7)                                                                                                                                                                                                        
    at node:internal/fs/streams:410:5                                                                                                                                                                                                                        
    at FSReqCallback.wrapper [as oncomplete] (node:fs:805:5) {       
```

The issue was that rename cannot cross partitions and some users had /tmp on a different partition than where the geocode was being created. See this [stackoverflow question](https://stackoverflow.com/questions/43206198/what-does-the-exdev-cross-device-link-not-permitted-error-mean).

Therefore instead of creating a temp file in the temp folder, this patch creates the temp file in the same output folder, just prefixes the file with "temp-". In housekeeping, it will then be deleted since it doesn't match the outputfilename